### PR TITLE
MigratableToken name for migrating_legacy_token_opt_in

### DIFF
--- a/migrating_legacy_token_opt_in/contracts/test/Token_V0.sol
+++ b/migrating_legacy_token_opt_in/contracts/test/Token_V0.sol
@@ -4,10 +4,10 @@ import 'zeppelin-solidity/contracts/token/ERC20/MintableToken.sol';
 import 'zeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 /**
- * @title Token_V0
- * @dev Version 0 of a token to show upgradeability.
+ * @title MigrationToken
+ * @dev migration version of the token, used for migrating balances
  */
-contract Token_V0 is MintableToken {
+contract MigrationToken is MintableToken {
 
   // Tells whether the token has been initialized or not
   bool internal _initialized;

--- a/migrating_legacy_token_opt_in/contracts/test/Token_V1.sol
+++ b/migrating_legacy_token_opt_in/contracts/test/Token_V1.sol
@@ -1,13 +1,15 @@
 pragma solidity ^0.4.18;
 
-import './Token_V0.sol';
 import 'zeppelin-solidity/contracts/token/ERC20/BurnableToken.sol';
 
 /**
  * @title Token_V1
- * @dev Version 1 of a token to show upgradeability.
- * The idea here is to extend a token behaviour providing burnable functionalities
- * in addition to what's provided in version 0
+ * @dev Version 1 of the token.
+ * The idea here is to extend a token behaviour providing,
+ * as an example, burnable functionalities,
+ * and removing the minting capabilities. 
+ * Note that the V1 implementation needs to share the same 
+ * storage structure as the MigrationToken
  */
-contract Token_V1 is Token_V0, BurnableToken {
+contract Token_V1 is BurnableToken {
 }

--- a/migrating_legacy_token_opt_in/test/migrateFromERC20.js
+++ b/migrating_legacy_token_opt_in/test/migrateFromERC20.js
@@ -4,7 +4,7 @@ const abi = require('ethereumjs-abi');
 
 var LegacyToken = artifacts.require('./LegacyToken.sol')
 const BurnContract = artifacts.require('./BurnContract.sol')
-const Token_V0 = artifacts.require('Token_V0')
+const MigrationToken = artifacts.require('MigrationToken')
 const OwnedUpgradeabilityProxy = artifacts.require('zos-upgradeability/contracts/upgradeability/OwnedUpgradeabilityProxy.sol')
 
 
@@ -22,15 +22,15 @@ contract('LegacyToken migration', function (accounts) {
 
     //Deploy new upgradeable token
     const proxy = await OwnedUpgradeabilityProxy.new();
-    const impl_v0 = await Token_V0.new()
+    const migration = await MigrationToken.new()
     const methodId = abi.methodID('initialize', ['address', 'address']).toString('hex')
     const params = abi.rawEncode(['address', 'address'],
       [legacyToken.address, burnContract.address])
       .toString('hex')
     const initializeData = '0x' + methodId + params
-    await proxy.upgradeToAndCall(impl_v0.address, initializeData)
+    await proxy.upgradeToAndCall(migration.address, initializeData)
 
-    newToken = await Token_V0.at(proxy.address)
+    newToken = await MigrationToken.at(proxy.address)
   });
 
   it('maintains correct balances after calling migrateToken', async function () {


### PR DESCRIPTION
Extract ideas in `migrating_legacy_token_opt_in` to `MigratableToken` helper contract so that in can be reused