### PR TITLE
Brought Migratable from zos-lib

### DIFF
--- a/migratable/contracts/Migratable.sol
+++ b/migratable/contracts/Migratable.sol
@@ -1,0 +1,94 @@
+pragma solidity ^0.4.24;
+
+
+/**
+ * @title Migratable
+ * DEPRECATED: For initialization please Initializable instead.
+ * Helper contract to support intialization and migration schemes between
+ * different implementations of a contract in the context of upgradeability.
+ * To use it, replace the constructor with a function that has the
+ * `isInitializer` modifier starting with `"0"` as `migrationId`.
+ * When you want to apply some migration code during an upgrade, increase
+ * the `migrationId`. Or, if the migration code must be applied only after
+ * another migration has been already applied, use the `isMigration` modifier.
+ * This helper supports multiple inheritance.
+ * WARNING: It is the developer's responsibility to ensure that migrations are
+ * applied in a correct order, or that they are run at all.
+ * See `Initializable` for a simpler version.
+ */
+contract Migratable {
+  /**
+   * @dev Emitted when the contract applies a migration.
+   * @param contractName Name of the Contract.
+   * @param migrationId Identifier of the migration applied.
+   */
+  event Migrated(string contractName, string migrationId);
+
+  /**
+   * @dev Mapping of the already applied migrations.
+   * (contractName => (migrationId => bool))
+   */
+  mapping (string => mapping (string => bool)) internal migrated;
+
+  /**
+   * @dev Internal migration id used to specify that a contract has already been initialized.
+   */
+  string constant private INITIALIZED_ID = "initialized";
+
+
+  /**
+   * @dev Modifier to use in the initialization function of a contract.
+   * @param contractName Name of the contract.
+   * @param migrationId Identifier of the migration.
+   */
+  modifier isInitializer(string contractName, string migrationId) {
+    validateMigrationIsPending(contractName, INITIALIZED_ID);
+    validateMigrationIsPending(contractName, migrationId);
+    _;
+    emit Migrated(contractName, migrationId);
+    migrated[contractName][migrationId] = true;
+    migrated[contractName][INITIALIZED_ID] = true;
+  }
+
+  /**
+   * @dev Modifier to use in the migration of a contract.
+   * @param contractName Name of the contract.
+   * @param requiredMigrationId Identifier of the previous migration, required
+   * to apply new one.
+   * @param newMigrationId Identifier of the new migration to be applied.
+   */
+  modifier isMigration(string contractName, string requiredMigrationId, string newMigrationId) {
+    require(isMigrated(contractName, requiredMigrationId), "Prerequisite migration ID has not been run yet");
+    validateMigrationIsPending(contractName, newMigrationId);
+    _;
+    emit Migrated(contractName, newMigrationId);
+    migrated[contractName][newMigrationId] = true;
+  }
+
+  /**
+   * @dev Returns true if the contract migration was applied.
+   * @param contractName Name of the contract.
+   * @param migrationId Identifier of the migration.
+   * @return true if the contract migration was applied, false otherwise.
+   */
+  function isMigrated(string contractName, string migrationId) public view returns(bool) {
+    return migrated[contractName][migrationId];
+  }
+
+  /**
+   * @dev Initializer that marks the contract as initialized.
+   * It is important to run this if you had deployed a previous version of a Migratable contract.
+   * For more information see https://github.com/zeppelinos/zos-lib/issues/158.
+   */
+  function initialize() isInitializer("Migratable", "1.2.1") public {
+  }
+
+  /**
+   * @dev Reverts if the requested migration was already executed.
+   * @param contractName Name of the contract.
+   * @param migrationId Identifier of the migration.
+   */
+  function validateMigrationIsPending(string contractName, string migrationId) private view {
+    require(!isMigrated(contractName, migrationId), "Requested target migration ID has already been run");
+  }
+}

--- a/migratable/contracts/mocks/AdminUpgradeabilityProxyMock.sol
+++ b/migratable/contracts/mocks/AdminUpgradeabilityProxyMock.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.24;
+
+import 'zos-lib/contracts/upgradeability/AdminUpgradeabilityProxy.sol';
+
+contract AdminUpgradeabilityProxyMock is AdminUpgradeabilityProxy {
+}

--- a/migratable/contracts/mocks/DummyImplementation.sol
+++ b/migratable/contracts/mocks/DummyImplementation.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.4.24;
+
+contract Impl {
+  function version() public pure returns (string);
+}
+
+contract DummyImplementation {
+  uint256 public value;
+  string public text;
+  uint256[] public values;
+
+  function initializeNonPayable() public {
+    value = 10;
+  }
+
+  function initializePayable() payable public {
+    value = 100;
+  }
+
+  function initializeNonPayable(uint256 _value) public {
+    value = _value;
+  }
+
+  function initializePayable(uint256 _value) payable public {
+    value = _value;
+  }
+
+  function initialize(uint256 _value, string _text, uint256[] _values) public {
+    value = _value;
+    text = _text;
+    values = _values;
+  }
+
+  function get() public pure returns (bool) {
+    return true;
+  }
+
+  function version() public pure returns (string) {
+    return "V1";
+  }
+
+  function reverts() public pure {
+    require(false);
+  }
+}
+
+contract DummyImplementationV2 is DummyImplementation {
+  function migrate(uint256 newVal) payable public {
+    value = newVal;
+  }
+
+  function version() public pure returns (string) {
+    return "V2";
+  }
+}

--- a/migratable/contracts/mocks/MigratableMock.sol
+++ b/migratable/contracts/mocks/MigratableMock.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.24;
+
+import '../Migratable.sol';
+
+/**
+ * @title MigratableMock
+ * @dev This contract is a mock to test upgradeability functionality
+ */
+contract MigratableMock is Migratable {
+  uint256 public x;
+
+  function initialize(uint256 value) public payable isInitializer("MigratableMock", "0") {
+    x = value;
+  }
+
+  function fail() public pure {
+    require(false, "MigratableMock forced failure");
+  }
+
+  function secondInitialize() public isInitializer("MigratableMock", "1") {
+  }
+}

--- a/migratable/contracts/mocks/MultipleInheritanceMigratableMocks.sol
+++ b/migratable/contracts/mocks/MultipleInheritanceMigratableMocks.sol
@@ -1,0 +1,138 @@
+pragma solidity ^0.4.24;
+
+import '../Migratable.sol';
+
+// Sample contracts showing upgradeability and migrations with multiple inheritance
+// Child contract inherits from Father and Mother contracts, and Father extends from Gramps
+//
+//              Gramps
+//                |
+//    Mother    Father
+//      |         |
+//      -- Child --
+//
+
+/**
+ * Sample base migratable contract that defines a field mother
+ */
+contract SampleMotherV1 is Migratable {
+  uint256 public mother;
+
+  function initialize(uint256 value) isInitializer("Mother", "migration_1") public {
+    mother = value;
+  }
+}
+
+/**
+ * V2 for base mother contract
+ */
+contract SampleMotherV2 is SampleMotherV1 {
+  function migrate(uint256 value) isMigration("Mother", "migration_1", "migration_2") public {
+    mother = value;
+  }
+}
+
+/**
+ * Sample base migratable contract that defines a field gramps
+ */
+contract SampleGrampsV1 is Migratable {
+  uint256 public gramps;
+
+  function initialize(uint256 value) isInitializer("Gramps", "migration_1") public {
+    gramps = value;
+  }
+}
+
+/**
+ * V2 for base gramps contract
+ */
+contract SampleGrampsV2 is SampleGrampsV1 {
+  function migrate(uint256 value) isMigration("Gramps", "migration_1", "migration_2") public {
+    gramps = value;
+  }
+}
+
+/**
+ * Sample base migratable contract that defines a field father and extends from gramps
+ */
+contract SampleFatherV1 is SampleGrampsV1 {
+  uint256 public father;
+
+  function initialize(uint256 _gramps, uint256 _father) isInitializer("Father", "migration_1") public {
+    SampleGrampsV1.initialize(_gramps);
+    father = _father;
+  }
+}
+
+/**
+ * V2 for base father contract, which extends from grampsV2
+ */
+contract SampleFatherV2 is SampleFatherV1, SampleGrampsV2 {
+  function migrate(uint256 _gramps, uint256 _father) isMigration("Father", "migration_1", "migration_2") public {
+    SampleGrampsV2.migrate(_gramps);
+    father = _father;
+  }
+}
+
+/**
+ * ChildV1 extends from motherV1, fatherV1 (grampsV1)
+ */
+contract SampleChildV1 is Migratable, SampleMotherV1, SampleFatherV1 {
+  uint256 public child;
+
+  function initialize(uint256 _mother, uint256 _gramps, uint256 _father, uint256 _child) isInitializer("Child", "migration_1") public {
+    SampleMotherV1.initialize(_mother);
+    SampleFatherV1.initialize(_gramps, _father);
+    child = _child;
+  }
+}
+
+/**
+ * ChildV2 extends from motherV1, fatherV1 (grampsV1)
+ */
+contract SampleChildV2 is SampleChildV1 {
+  function migrate(uint256 _child) isMigration("Child", "migration_1", "migration_2") public {
+    child = _child;
+  }
+}
+
+/**
+ * ChildV3 extends from motherV2, fatherV1 (grampsV1)
+ */
+contract SampleChildV3 is SampleChildV2, SampleMotherV2  {
+  function migrate(uint256 _mother, uint256 _child) isMigration("Child", "migration_2", "migration_3") public {
+    SampleMotherV2.migrate(_mother);
+    child = _child;
+  }
+}
+
+/**
+ * ChildV4 extends from motherV2, fatherV2 (grampsV2)
+ */
+contract SampleChildV4 is SampleChildV3, SampleFatherV2  {
+  function migrate(uint256 _gramps, uint256 _father, uint256 _child) isMigration("Child", "migration_3", "migration_4") public {
+    SampleFatherV2.migrate(_gramps, _father);
+    child = _child;
+  }
+}
+
+/**
+ * ChildV5 extends from motherV2, fatherV2 (grampsV2), has the same signature in migrate than V1, and allows to be initialized directly as well or from V3
+ */
+contract SampleChildV5 is SampleChildV4 {
+  function initialize(uint256 _mother, uint256 _gramps, uint256 _father, uint256 _child) isInitializer("Child", "migration_5") public {
+    SampleMotherV1.initialize(_mother);
+    SampleMotherV2.migrate(_mother);
+    SampleFatherV1.initialize(_gramps, _father);
+    SampleFatherV2.migrate(_gramps, _father);
+    child = _child;
+  }
+
+  function migrateFromV3(uint256 _gramps, uint256 _father, uint256 _child) isMigration("Child", "migration_3", "migration_5") public {
+    SampleChildV4.migrate(_gramps, _father, _child);
+  }
+
+  function migrate(uint256 _child) isMigration("Child", "migration_4", "migration_5") public {
+    child = _child;
+  }
+}

--- a/migratable/contracts/mocks/SingleInheritanceMigratableMocks.sol
+++ b/migratable/contracts/mocks/SingleInheritanceMigratableMocks.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.24;
+
+import '../Migratable.sol';
+
+/**
+ * @title MigratableMockV1
+ * @dev This contract is a mock to test initializable functionality through migrations
+ */
+contract MigratableMockV1 is Migratable {
+  uint256 public x;
+
+  function initialize(uint256 value) isInitializer("MigratableMock", "migration_1") public payable {
+    x = value;
+  }
+}
+
+/**
+ * @title MigratableMockV2
+ * @dev This contract is a mock to test migratable functionality with params
+ */
+contract MigratableMockV2 is MigratableMockV1 {
+  uint256 public y;
+
+  function migrate(uint256 value, uint256 anotherValue) isMigration("MigratableMock", "migration_1", "migration_2") public payable {
+    x = value;
+    y = anotherValue;
+  }
+}
+
+/**
+ * @title MigratableMockV3
+ * @dev This contract is a mock to test migratable functionality without params
+ */
+contract MigratableMockV3 is MigratableMockV2 {
+  function migrate() isMigration("MigratableMock", "migration_2", "migration_3") public payable {
+    uint256 oldX = x;
+    x = y;
+    y = oldX;
+  }
+}

--- a/migratable/package-lock.json
+++ b/migratable/package-lock.json
@@ -1,0 +1,1408 @@
+{
+  "name": "migratable",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "dev": true
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-sha3": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
+      "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+      "dev": true,
+      "requires": {
+        "js-sha3": "^0.3.1"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-bignumber": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/chai-bignumber/-/chai-bignumber-2.0.2.tgz",
+      "integrity": "sha512-BIdRNjRaoRj4bMsZLKbIZPMNKqmwnzNiyxqBYDSs6dFOCs9w8OHPuUE8e1bH60i1IhOzT0NjLtCD+lKEWB1KTQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "crypto-js": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "4.5.0",
+      "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+      "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.8.0",
+        "create-hash": "^1.1.2",
+        "keccakjs": "^0.2.0",
+        "rlp": "^2.0.0",
+        "secp256k1": "^3.0.1"
+      }
+    },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "js-sha3": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+      "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "keccakjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
+      "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+      "dev": true,
+      "requires": {
+        "browserify-sha3": "^0.0.1",
+        "sha3": "^1.1.0"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "openzeppelin-solidity": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg==",
+      "dev": true
+    },
+    "original-require": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
+      "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rlp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
+      "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "secp256k1": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
+      "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+      "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+      "dev": true,
+      "requires": {
+        "nan": "2.10.0"
+      }
+    },
+    "solc": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^0.30.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^1.1.0",
+        "semver": "^5.3.0",
+        "yargs": "^4.7.1"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^2.0.0"
+      }
+    },
+    "truffle": {
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
+      "integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+      "dev": true,
+      "requires": {
+        "mocha": "^4.1.0",
+        "original-require": "1.0.1",
+        "solc": "0.4.24"
+      }
+    },
+    "truffle-blockchain-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
+      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc=",
+      "dev": true
+    },
+    "truffle-config": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.6.tgz",
+      "integrity": "sha1-GB2n0xnAxV6yeB1cGIapx/MvpHA=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "lodash": "4.17.10",
+        "original-require": "1.0.1",
+        "truffle-error": "^0.0.3",
+        "truffle-provider": "^0.0.6"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
+      }
+    },
+    "truffle-contract": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
+      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
+      "dev": true,
+      "requires": {
+        "ethjs-abi": "0.1.8",
+        "truffle-blockchain-utils": "^0.0.5",
+        "truffle-contract-schema": "^2.0.1",
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
+      }
+    },
+    "truffle-contract-schema": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
+      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.1",
+        "crypto-js": "^3.1.9-1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "3.1.9-1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+          "dev": true
+        }
+      }
+    },
+    "truffle-error": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
+      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=",
+      "dev": true
+    },
+    "truffle-provider": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.6.tgz",
+      "integrity": "sha1-caku1nY2raXniQVpDXLqkirUphM=",
+      "dev": true,
+      "requires": {
+        "truffle-error": "^0.0.3",
+        "web3": "0.20.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.20.6",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "crypto-js": "^3.1.4",
+            "utf8": "^2.1.1",
+            "xhr2": "*",
+            "xmlhttprequest": "*"
+          }
+        }
+      }
+    },
+    "truffle-provisioner": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.1.tgz",
+      "integrity": "sha1-WoMn1iUR7yPJUNOqhiYQp8N34qo=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "web3": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+      "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "dev": true
+        }
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "4.8.1",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "dev": true,
+      "requires": {
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "lodash.assign": "^4.0.3",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.1",
+        "which-module": "^1.0.0",
+        "window-size": "^0.2.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^2.4.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "2.4.1",
+      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
+      }
+    },
+    "zos-lib": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-1.4.1.tgz",
+      "integrity": "sha512-JVVubliVtXi2XKkWKxRf17UcRkFE79YDePYdAsyoLkU/Gxo2322lT49Fc6a7pyQNt4qEu9vkIk5QiPMGKi5UOw==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^7.2.0",
+        "chalk": "^2.4.1",
+        "ethereumjs-abi": "^0.6.5",
+        "openzeppelin-solidity": "~1.10.0",
+        "truffle-config": "^1.0.6",
+        "truffle-contract": "^3.0.6",
+        "truffle-provisioner": "^0.1.1",
+        "web3": "^0.18.4"
+      }
+    }
+  }
+}

--- a/migratable/package.json
+++ b/migratable/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "migratable",
+  "scripts": {
+    "test": "npx truffle test"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "chai-bignumber": "^2.0.2",
+    "truffle": "^4.1.14",
+    "zos-lib": "^1.4.1"
+  }
+}

--- a/migratable/test/contracts/Migratable.test.js
+++ b/migratable/test/contracts/Migratable.test.js
@@ -1,0 +1,373 @@
+process.env.NODE_ENV = 'test'
+
+require('chai')
+  .use(require('chai-bignumber')(web3.BigNumber))
+  .should()
+
+require('zos-lib/lib/helpers/encodeCall').default;
+
+const encodeCall = require('zos-lib/lib/helpers/encodeCall');
+const decodeLogs = require('zos-lib/lib/helpers/decodeLogs');
+const assertRevert = require('zos-lib/lib/test/helpers/assertRevert');
+
+const Migratable = artifacts.require('Migratable');
+const MigratableMock = artifacts.require('MigratableMock');
+const SampleChildV1 = artifacts.require('SampleChildV1');
+const SampleChildV2 = artifacts.require('SampleChildV2');
+const SampleChildV3 = artifacts.require('SampleChildV3');
+const SampleChildV4 = artifacts.require('SampleChildV4');
+const SampleChildV5 = artifacts.require('SampleChildV5');
+const DummyImplementation = artifacts.require('DummyImplementation');
+const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxyMock');
+
+contract('Migratable', function ([_, owner, registrar]) {
+  const from = owner;
+  let v0, v1, v2, v3, v4, v5;
+
+  before(async function () {
+    v0 = await DummyImplementation.new({ from: registrar });
+    v1 = await SampleChildV1.new({ from: registrar });
+    v2 = await SampleChildV2.new({ from: registrar });
+    v3 = await SampleChildV3.new({ from: registrar });
+    v4 = await SampleChildV4.new({ from: registrar });
+    v5 = await SampleChildV5.new({ from: registrar });
+  });
+
+  beforeEach(async function () {
+    const initializeData = ''
+    this.proxy = await AdminUpgradeabilityProxy.new(v0.address, initializeData, { from });
+    this.contract = SampleChildV1.at(this.proxy.address);
+  });
+
+  const getMigrationLogs = (rawTx) => {
+    return decodeLogs(rawTx.receipt.logs.slice(1), Migratable)
+        .filter(log => log.event === 'Migrated');
+  };
+
+  const assertMigrationEvent = (logs, contractName, migrationId) => {
+    logs.map(log => log.args).should.deep.include({ contractName, migrationId })
+  };
+
+  const upgradeToAndCall = (target, implementation, method, args, values, opts) => {
+    const data = encodeCall(method, args, values);
+    return target.upgradeToAndCall(implementation.address, data, opts || {});
+  };
+
+  const sendTransaction = (target, method, args, values, opts) => {
+    const data = encodeCall(method, args, values);
+    return target.sendTransaction(Object.assign({ data }, opts));
+  };
+
+
+  // Initializing to V1
+  // ------------------
+
+  const motherV1 = 110, grampsV1 = 120, fatherV1 = 130, childV1 = 140;
+  const initialize = (proxy) => upgradeToAndCall(proxy, v1, 'initialize', ['uint256', 'uint256', 'uint256', 'uint256'], [motherV1, grampsV1, fatherV1, childV1], { from });
+
+  describe('initializing a contract', async function () {
+
+    beforeEach(async function () {
+      (this.tx = await initialize(this.proxy));
+    })
+
+    it('should run child initializer', async function () {
+      (await this.contract.child()).should.be.bignumber.eq(childV1);
+    });
+
+    it('cannot run an initializer twice', async function () {
+      await assertRevert(initialize(this.proxy))
+    });
+
+    it('should run ancestor initializers', async function () {
+      (await this.contract.mother()).should.be.bignumber.eq(motherV1);
+      (await this.contract.gramps()).should.be.bignumber.eq(grampsV1);
+      (await this.contract.father()).should.be.bignumber.eq(fatherV1);
+    });
+
+    it('should fire logs for all migrations', async function () {
+      const logs = getMigrationLogs(this.tx);
+      logs.should.have.lengthOf(4);
+      assertMigrationEvent(logs, 'Child', 'migration_1');
+      assertMigrationEvent(logs, 'Mother', 'migration_1');
+      assertMigrationEvent(logs, 'Father',  'migration_1');
+      assertMigrationEvent(logs, 'Gramps', 'migration_1');
+    });
+
+    it('should track migration for child contract', async function () {
+      (await this.contract.isMigrated('Child', 'migration_1')).should.be.true;
+    });
+
+    it('should track migration for ancestor contracts', async function () {
+      (await this.contract.isMigrated('Father', 'migration_1')).should.be.true;
+      (await this.contract.isMigrated('Mother', 'migration_1')).should.be.true;
+      (await this.contract.isMigrated('Gramps', 'migration_1')).should.be.true;
+    });
+
+    it('should not allow initialization to be re-run', async function () {
+      await assertRevert(sendTransaction(this.proxy, 'initialize', ['uint256', 'uint256', 'uint256', 'uint256'], [1,2,3,4], { from }));
+    });
+
+    it('should not allow initialization of ancestor to be re-run', async function () {
+      await assertRevert(sendTransaction(this.proxy, 'initialize', ['uint256', 'uint256'], [1,2], { from }));
+    });
+  });
+
+
+  // Migrating to V2
+  // ---------------
+
+  const childV2 = 240;
+  const migrateToV2 = (proxy) => upgradeToAndCall(proxy, v2, 'migrate', ['uint256'], [childV2], { from });
+
+  describe('migrating to v2', async function () {
+    describe('once initialized', async function () {
+      beforeEach(async function () {
+        await initialize(this.proxy);
+        this.tx = await migrateToV2(this.proxy);
+        this.contract = SampleChildV2.at(this.proxy.address);
+      })
+
+      it('should update child value', async function () {
+        (await this.contract.child()).should.be.bignumber.eq(childV2);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(1);
+        assertMigrationEvent(logs, 'Child', 'migration_2');
+      });
+
+      it('should track migration for child contract', async function () {
+        (await this.contract.isMigrated('Child', 'migration_2')).should.be.true;
+      });
+
+      it('should not allow to re-run migration', async function () {
+        await assertRevert(sendTransaction(this.proxy, 'migrate', ['uint256'], [1], { from }));
+      });
+    });
+
+    it('should fail if uninitialized', async function () {
+      await assertRevert(migrateToV2(this.proxy));
+    });
+  });
+
+
+  // Migrating to V3
+  // ---------------
+
+  const motherV2 = 210, childV3 = 340;
+  const migrateToV3 = (proxy) => upgradeToAndCall(proxy, v3, 'migrate', ['uint256', 'uint256'], [motherV2, childV3], { from });
+
+  describe('migrating to v3', async function () {
+    describe('from v2', async function () {
+      beforeEach(async function () {
+        await initialize(this.proxy);
+        await migrateToV2(this.proxy);
+        this.tx = await migrateToV3(this.proxy);
+        this.contract = SampleChildV3.at(this.proxy.address);
+      })
+
+      it('should update all values', async function () {
+        (await this.contract.mother()).should.be.bignumber.eq(motherV2);
+        (await this.contract.child()).should.be.bignumber.eq(childV3);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(2);
+        assertMigrationEvent(logs, 'Child', 'migration_3');
+        assertMigrationEvent(logs, 'Mother', 'migration_2');
+      });
+
+      it('should track migration for all contracts', async function () {
+        (await this.contract.isMigrated('Child', 'migration_3')).should.be.true;
+        (await this.contract.isMigrated('Mother', 'migration_2')).should.be.true;
+      });
+
+      it('should not allow to re-run migration', async function () {
+        await assertRevert(sendTransaction(this.proxy, 'migrate', ['uint256', 'uint256'], [1,2], { from }));
+      });
+    });
+
+    it('should fail if not migrated to v2', async function () {
+      await initialize(this.proxy);
+      await assertRevert(migrateToV3(this.proxy));
+    });
+  });
+
+
+  // Migrating to V4
+  // ---------------
+
+  const grampsV2 = 220, fatherV2 = 230, childV4 = 440;
+  const migrateToV4 = (proxy) => upgradeToAndCall(proxy, v4, 'migrate', ['uint256', 'uint256', 'uint256'], [grampsV2, fatherV2, childV4], { from });
+
+  describe('migrating to v4', async function () {
+    describe('from v3', async function () {
+      beforeEach(async function () {
+        await initialize(this.proxy);
+        await migrateToV2(this.proxy);
+        await migrateToV3(this.proxy);
+        this.tx = await migrateToV4(this.proxy);
+        this.contract = SampleChildV4.at(this.proxy.address);
+      })
+
+      it('should update all values', async function () {
+        (await this.contract.gramps()).should.be.bignumber.eq(grampsV2);
+        (await this.contract.father()).should.be.bignumber.eq(fatherV2);
+        (await this.contract.child()).should.be.bignumber.eq(childV4);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(3);
+        assertMigrationEvent(logs, 'Child', 'migration_4');
+        assertMigrationEvent(logs, 'Gramps', 'migration_2');
+        assertMigrationEvent(logs, 'Father', 'migration_2');
+      });
+
+      it('should track migration for all contracts', async function () {
+        (await this.contract.isMigrated('Child', 'migration_3')).should.be.true;
+        (await this.contract.isMigrated('Gramps', 'migration_2')).should.be.true;
+        (await this.contract.isMigrated('Father', 'migration_2')).should.be.true;
+      });
+
+      it('should not allow to re-run migration', async function () {
+        await assertRevert(sendTransaction(this.proxy, 'migrate', ['uint256', 'uint256', 'uint256'], [1,2,3], { from }));
+      });
+    });
+
+    it('should fail if not migrated to v3', async function () {
+      await initialize(this.proxy);
+      await migrateToV2(this.proxy)
+      await assertRevert(migrateToV4(this.proxy));
+    });
+  });
+
+
+  // Migrating to V5
+  // ---------------
+
+  const childV5 = 540;
+  const migrateToV5 = (proxy) => upgradeToAndCall(proxy, v5, 'migrate', ['uint256'], [childV5], { from });
+  const migrateToV5FromV3 = (proxy) => upgradeToAndCall(proxy, v5, 'migrateFromV3', ['uint256','uint256','uint256'], [grampsV2, fatherV2, childV5], { from });
+  const migrateToV5FromScratch = (proxy) => upgradeToAndCall(proxy, v5, 'initialize', ['uint256','uint256','uint256','uint256'], [motherV2, grampsV2, fatherV2, childV5], { from });
+
+  describe('migrating to v5', async function () {
+    describe('from v4', async function () {
+      beforeEach(async function () {
+        await initialize(this.proxy);
+        await migrateToV2(this.proxy);
+        await migrateToV3(this.proxy);
+        await migrateToV4(this.proxy);
+        this.tx = await migrateToV5(this.proxy);
+        this.contract = SampleChildV5.at(this.proxy.address);
+      })
+
+      it('should update child value', async function () {
+        (await this.contract.child()).should.be.bignumber.eq(childV5);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(1);
+        assertMigrationEvent(logs, 'Child', 'migration_5');
+      });
+
+      it('should track migration for all contracts', async function () {
+        (await this.contract.isMigrated('Child', 'migration_5')).should.be.true;
+      });
+
+      it('should not allow to re-run migration', async function () {
+        await assertRevert(sendTransaction(this.proxy, 'migrate', ['uint256'], [1], { from }));
+      });
+    });
+
+    describe('from v3', async function () {
+      beforeEach(async function () {
+        await initialize(this.proxy);
+        await migrateToV2(this.proxy);
+        await migrateToV3(this.proxy);
+        this.tx = await migrateToV5FromV3(this.proxy);
+        this.contract = SampleChildV5.at(this.proxy.address);
+      })
+
+      it('should update all values', async function () {
+        (await this.contract.child()).should.be.bignumber.eq(childV5);
+        (await this.contract.gramps()).should.be.bignumber.eq(grampsV2);
+        (await this.contract.father()).should.be.bignumber.eq(fatherV2);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(4);
+        assertMigrationEvent(logs, 'Child', 'migration_4');
+        assertMigrationEvent(logs, 'Child', 'migration_5');
+        assertMigrationEvent(logs, 'Gramps', 'migration_2');
+        assertMigrationEvent(logs, 'Father', 'migration_2');
+      });
+
+      it('should track migration for all contracts', async function () {
+        (await this.contract.isMigrated('Child', 'migration_5')).should.be.true;
+        (await this.contract.isMigrated('Gramps', 'migration_2')).should.be.true;
+        (await this.contract.isMigrated('Father', 'migration_2')).should.be.true;
+      });
+
+      it('should not allow to re-run migration', async function () {
+        await assertRevert(sendTransaction(this.proxy, 'migrate', ['uint256'], [1], { from }));
+      });
+    });
+
+    describe('from scratch', async function () {
+      beforeEach(async function () {
+        this.tx = await migrateToV5FromScratch(this.proxy);
+        this.contract = SampleChildV5.at(this.proxy.address);
+      })
+
+      it('should set all values', async function () {
+        (await this.contract.child()).should.be.bignumber.eq(childV5);
+        (await this.contract.gramps()).should.be.bignumber.eq(grampsV2);
+        (await this.contract.father()).should.be.bignumber.eq(fatherV2);
+        (await this.contract.mother()).should.be.bignumber.eq(motherV2);
+      });
+
+      it('should fire logs for all migrations', async function () {
+        const logs = getMigrationLogs(this.tx);
+        logs.should.have.lengthOf(7);
+        assertMigrationEvent(logs, 'Child', 'migration_5');
+        assertMigrationEvent(logs, 'Gramps', 'migration_1');
+        assertMigrationEvent(logs, 'Gramps', 'migration_2');
+        assertMigrationEvent(logs, 'Father', 'migration_1');
+        assertMigrationEvent(logs, 'Father', 'migration_2');
+        assertMigrationEvent(logs, 'Mother', 'migration_1');
+        assertMigrationEvent(logs, 'Mother', 'migration_2');
+      });
+
+      it('should track migration for all contracts', async function () {
+        (await this.contract.isMigrated('Child', 'migration_5')).should.be.true;
+        (await this.contract.isMigrated('Gramps', 'migration_2')).should.be.true;
+        (await this.contract.isMigrated('Father', 'migration_2')).should.be.true;
+      });
+    });
+  });
+
+  describe('an initialized migratable', function () {
+    beforeEach('creating initialized migratable', async function () {
+      this.migratable = await MigratableMock.new();
+      sendTransaction(this.migratable, 'initialize', ['uint256'], [0]);
+    });
+
+    it('should not allow rerunning the initializer', async function () {
+      await assertRevert(
+        sendTransaction(this.migratable, 'initialize', ['uint256'], [0])
+      );
+    });
+
+    it('should not allow running another initializer', async function () {
+      await assertRevert(
+        sendTransaction(this.migratable, 'secondInitialize')
+      );
+    });
+  });
+});

--- a/migratable/test/helpers/encodeCall.js
+++ b/migratable/test/helpers/encodeCall.js
@@ -1,0 +1,19 @@
+const abi = require('ethereumjs-abi');
+const BN = require('bignumber.js');
+
+function formatValue(value) {
+  if (typeof(value) === 'number' || BN.isBigNumber(value)) {
+    return value.toString();
+  } else {
+    return value;
+  }
+}
+
+function encodeCall(name, args = [], rawValues = []) {
+  const values = rawValues.map(formatValue)
+  const methodId = abi.methodID(name, args).toString('hex');
+  const params = abi.rawEncode(args, values).toString('hex');
+  return '0x' + methodId + params;
+}
+
+module.exports = encodeCall;

--- a/migratable/truffle.js
+++ b/migratable/truffle.js
@@ -1,0 +1,10 @@
+module.exports = {
+  networks: {
+   local: {
+      network_id: '*',
+      host: 'localhost',
+      port: 8545,
+      gas: 6700000,
+    },
+  },
+}


### PR DESCRIPTION
`Migratable` is being removed in https://github.com/zeppelinos/zos/pull/220, so we're storing it here.

The test suite is currently failing on the `upgradeAndCall` call, though I'm not sure why, since the contracts are the same.